### PR TITLE
Add alpine/edge/community to apk repositories in nomad script

### DIFF
--- a/scripts/nomad.sh
+++ b/scripts/nomad.sh
@@ -3,6 +3,7 @@
 echo "==> Installing Nomad"
 
 echo "https://sjc.edge.kernel.org/alpine/edge/testing" | tee -a /etc/apk/repositories
+echo "https://sjc.edge.kernel.org/alpine/edge/community" | tee -a /etc/apk/repositories
 apk update
 apk add nomad ip6tables
 


### PR DESCRIPTION
Hi Andy, found your blog when I started learning the hashi-stack. This vagrant image is an indispensable development and learning tool, thanks for your work.
 
It looks like since [this commit](https://git.alpinelinux.org/aports/commit/testing?id=aa5480c875222fb6725c1910e678d0e9b5055e70), `cni-plugins` was moved from the `testing` apk repos to `community`. This causes an error when trying to install nomad:

```
alpine310:/home/vagrant# apk add nomad
ERROR: unsatisfiable constraints:
  cni-plugins (missing):
    required by: nomad-0.11.3-r0[cni-plugins]
```

Adding the community source URL (https://sjc.edge.kernel.org/alpine/edge/community) to `/etc/apk/repositories` fixes this issue.